### PR TITLE
Omit Export of /etc/krb5.keytab

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -x
 set -e
 
 SAMBA_DOMAIN=${SAMBA_DOMAIN:-SAMDOM}
@@ -22,7 +22,7 @@ appSetup () {
     echo Samba administrator password: $SAMBA_ADMIN_PASSWORD
     echo Kerberos KDC database master key: $KERBEROS_PASSWORD
 
-    # Provision Samba
+    # Provision Sambac
     rm -f /etc/samba/smb.conf
     rm -rf /var/lib/samba/private/*
     samba-tool domain provision --use-rfc2307 --domain=$SAMBA_DOMAIN --realm=$SAMBA_REALM --server-role=dc\
@@ -36,8 +36,12 @@ appSetup () {
 	fi
     # Create Kerberos database
     expect kdb5_util_create.expect
+    
     # Export kerberos keytab for use with sssd
-    samba-tool domain exportkeytab /etc/krb5.keytab --principal ${HOSTNAME}\$
+    if [ "${OMIT_EXPORT_KEY_TAB}" != "true" ]
+    then
+        samba-tool domain exportkeytab /etc/krb5.keytab --principal ${HOSTNAME}\$
+    fi
     sed -i "s/SAMBA_REALM/${SAMBA_REALM}/" /etc/sssd/sssd.conf
 }
 

--- a/init.sh
+++ b/init.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -x
+
 set -e
 
 SAMBA_DOMAIN=${SAMBA_DOMAIN:-SAMDOM}
@@ -22,7 +22,7 @@ appSetup () {
     echo Samba administrator password: $SAMBA_ADMIN_PASSWORD
     echo Kerberos KDC database master key: $KERBEROS_PASSWORD
 
-    # Provision Sambac
+    # Provision Samba
     rm -f /etc/samba/smb.conf
     rm -rf /var/lib/samba/private/*
     samba-tool domain provision --use-rfc2307 --domain=$SAMBA_DOMAIN --realm=$SAMBA_REALM --server-role=dc\


### PR DESCRIPTION
In some environments (e.g. kubernetes) the setup fails because the kerberos ketab can not be exported:

``` python
ERROR(runtime): uncaught exception - Key table entry not found
  File "/usr/lib/python2.7/dist-packages/samba/netcmd/__init__.py", line 175, in _run
    return self.run(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/samba/netcmd/domain.py", line 117, in run
    net.export_keytab(keytab=keytab, principal=principal)
```

When Kerberos is not required this can be omited as a workaround. 
