### PR TITLE
Fix: Restore Domain-Controller from Volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,4 +53,4 @@ ADD init.sh /init.sh
 RUN chmod 755 /init.sh
 EXPOSE 22 53 389 88 135 139 138 445 464 3268 3269
 ENTRYPOINT ["/init.sh"]
-CMD ["app:setup_start"]
+CMD ["app:start"]


### PR DESCRIPTION
In the previous version it was not possible to persist users because the volume /var/lib/samba did not restore samba config files in /etc/...
